### PR TITLE
fix(swagger, auth): $ref 해석 오류 및 AdminGuard 인증 처리 안정화

### DIFF
--- a/apps/blog-api/src/auth/guards/admin.guard.ts
+++ b/apps/blog-api/src/auth/guards/admin.guard.ts
@@ -3,9 +3,9 @@ import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Injectable()
 export class AdminGuard extends JwtAuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
-    // 먼저 JWT 인증 확인
-    const isAuthenticated = super.canActivate(context);
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    // 먼저 JWT 인증 확인 (비동기 결과를 반드시 대기)
+    const isAuthenticated = await super.canActivate(context);
     if (!isAuthenticated) return false;
 
     // 요청 객체에서 사용자 정보 가져오기

--- a/apps/blog-api/src/main.ts
+++ b/apps/blog-api/src/main.ts
@@ -8,6 +8,7 @@ import { AppModule } from './app.module';
 import { CategoriesModule } from './categories/categories.module';
 import { PostsModule } from './posts/posts.module';
 import { TagsModule } from './tags/tags.module';
+import { ApiResponseDto, PaginatedApiResponseDto, ApiResponseMeta } from './common/dto';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -85,6 +86,7 @@ async function bootstrap() {
 
   const document = SwaggerModule.createDocument(app, config, {
     include: [PostsModule, CategoriesModule, TagsModule],
+    extraModels: [ApiResponseDto, PaginatedApiResponseDto, ApiResponseMeta],
   });
   SwaggerModule.setup('api-docs', app, document, {
     swaggerOptions: {


### PR DESCRIPTION
  - Swagger 문서: 공통 응답 DTO(ApiResponseDto, PaginatedApiResponseDto, ApiResponseMeta)를 extraModels로 전역 등록해 $ref: getSchemaPath(ApiResponseDto) 해석 오류 해결
  - 인증 가드: AdminGuard.canActivate를 async/await로 수정해 Passport JWT 인증 결과를 대기, 인증 실패 시 unhandled rejection 방지 및 401/403 응답 일관화
  - 영향: Swagger UI 정상 렌더링, POST /api/posts 등 보호 엔드포인트에서 서버 종료처럼 보이던 현상 방지