### PR TITLE
feat(web): render paginated posts from API

### DIFF
--- a/apps/blog-web/app/page.module.css
+++ b/apps/blog-web/app/page.module.css
@@ -1,188 +1,268 @@
 .page {
-  --gray-rgb: 0, 0, 0;
-  --gray-alpha-200: rgba(var(--gray-rgb), 0.08);
-  --gray-alpha-100: rgba(var(--gray-rgb), 0.05);
-
-  --button-primary-hover: #383838;
-  --button-secondary-hover: #f2f2f2;
-
-  display: grid;
-  grid-template-rows: 20px 1fr 20px;
-  align-items: center;
-  justify-items: center;
-  min-height: 100svh;
-  padding: 80px;
-  gap: 64px;
-  font-synthesis: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  .page {
-    --gray-rgb: 255, 255, 255;
-    --gray-alpha-200: rgba(var(--gray-rgb), 0.145);
-    --gray-alpha-100: rgba(var(--gray-rgb), 0.06);
-
-    --button-primary-hover: #ccc;
-    --button-secondary-hover: #1a1a1a;
-  }
-}
-
-.main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 64px 24px 96px;
   display: flex;
   flex-direction: column;
   gap: 32px;
-  grid-row-start: 2;
 }
 
-.main ol {
-  font-family: var(--font-geist-mono);
-  padding-left: 0;
-  margin: 0;
-  font-size: 14px;
-  line-height: 24px;
-  letter-spacing: -0.01em;
-  list-style-position: inside;
-}
-
-.main li:not(:last-of-type) {
-  margin-bottom: 8px;
-}
-
-.main code {
-  font-family: inherit;
-  background: var(--gray-alpha-100);
-  padding: 2px 4px;
-  border-radius: 4px;
-  font-weight: 600;
-}
-
-.ctas {
+.header {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.title {
+  font-size: clamp(2.25rem, 3vw, 2.75rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-lg);
+  line-height: 1.6;
+  max-width: 720px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
   gap: 16px;
 }
 
-.ctas a {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: none;
-  font-family: var(--font-geist-sans);
-  border: 1px solid transparent;
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
-  cursor: pointer;
+.limitSelector {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
-  font-weight: 500;
+  gap: 12px;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
-a.primary {
-  background: var(--foreground);
-  color: var(--background);
-  gap: 8px;
+.limitSelectorLabel {
+  font-weight: 600;
 }
 
-a.secondary {
-  border-color: var(--gray-alpha-200);
-  min-width: 180px;
-}
-
-button.secondary {
-  appearance: none;
-  border-radius: 128px;
-  height: 48px;
-  padding: 0 20px;
-  border: none;
-  font-family: var(--font-geist-sans);
-  border: 1px solid transparent;
-  transition: background 0.2s, color 0.2s, border-color 0.2s;
-  cursor: pointer;
-  display: flex;
+.limitButton {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: 16px;
-  line-height: 20px;
+  min-width: 40px;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: inherit;
   font-weight: 500;
-  background: transparent;
-  border-color: var(--gray-alpha-200);
-  min-width: 180px;
+  transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
-.footer {
-  font-family: var(--font-geist-sans);
-  grid-row-start: 3;
-  display: flex;
+.limitButton:hover {
+  background-color: var(--secondary);
+  border-color: transparent;
+  color: var(--primary);
+}
+
+.limitButtonActive {
+  background-color: var(--primary);
+  border-color: var(--primary);
+  color: var(--primary-foreground);
+  cursor: default;
+  pointer-events: none;
+}
+
+.summary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.grid {
+  display: grid;
   gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
-.footer a {
+.card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: var(--card);
+  color: var(--card-foreground);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+  height: 100%;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.14);
+  border-color: transparent;
+}
+
+.card h2 {
+  margin: 0 0 12px;
+  font-size: var(--font-size-2xl);
+  line-height: 1.2;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.footer img {
-  flex-shrink: 0;
+.card h2 span {
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 1.5rem;
 }
 
-/* Enable hover only on non-touch devices */
-@media (hover: hover) and (pointer: fine) {
-  a.primary:hover {
-    background: var(--button-primary-hover);
-    border-color: transparent;
-  }
-
-  a.secondary:hover {
-    background: var(--button-secondary-hover);
-    border-color: transparent;
-  }
-
-  .footer a:hover {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-  }
+.card:hover h2 span {
+  opacity: 1;
+  transform: translateX(0);
 }
 
-@media (max-width: 600px) {
+.card p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.meta {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.excerpt {
+  font-size: var(--font-size-base);
+  color: var(--card-foreground);
+  font-weight: 500;
+  line-height: 1.7;
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.paginationButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 9999px;
+  border: 1px solid var(--border);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-primary);
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  min-width: 96px;
+}
+
+.paginationButton:hover {
+  background-color: var(--secondary);
+  border-color: transparent;
+  color: var(--primary);
+}
+
+.paginationButtonDisabled {
+  background-color: transparent;
+  color: var(--color-text-secondary);
+  border-style: dashed;
+  cursor: not-allowed;
+}
+
+.paginationInfo {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.empty,
+.error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  border-radius: 16px;
+  border: 1px dashed var(--border);
+  background-color: var(--secondary);
+  text-align: center;
+}
+
+.error {
+  background-color: rgba(239, 68, 68, 0.1);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: var(--color-accent-error);
+}
+
+.errorMessage {
+  font-size: var(--font-size-base);
+  font-weight: 600;
+}
+
+@media (max-width: 768px) {
   .page {
-    padding: 32px;
-    padding-bottom: 80px;
+    padding: 48px 20px 72px;
   }
 
-  .main {
-    align-items: center;
+  .title {
+    font-size: clamp(1.9rem, 6vw, 2.4rem);
   }
 
-  .main ol {
-    text-align: center;
+  .subtitle {
+    font-size: var(--font-size-base);
   }
 
-  .ctas {
+  .card {
+    padding: 20px;
+  }
+
+  .card h2 {
+    font-size: var(--font-size-xl);
+  }
+}
+
+@media (max-width: 480px) {
+  .page {
+    padding: 32px 16px 64px;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .limitSelector {
+    width: 100%;
+    justify-content: flex-start;
+    gap: 8px;
+  }
+
+  .pagination {
     flex-direction: column;
   }
 
-  .ctas a {
-    font-size: 14px;
-    height: 40px;
-    padding: 0 16px;
-  }
-
-  a.secondary {
-    min-width: auto;
-  }
-
-  .footer {
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .logo {
-    filter: invert();
+  .paginationButton {
+    width: 100%;
   }
 }

--- a/apps/blog-web/app/page.tsx
+++ b/apps/blog-web/app/page.tsx
@@ -1,103 +1,299 @@
-import Image, { type ImageProps } from "next/image";
+import Link from "next/link";
 
-import { Button } from "@repo/ui/button";
+import { Card } from "@repo/ui/card";
+import type { ApiResponse, PaginatedResponse, PostWithRelations } from "@repo/shared";
+
 import styles from "./page.module.css";
 
-type Props = Omit<ImageProps, "src"> & {
-  srcLight: string;
-  srcDark: string;
-};
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 9;
+const MAX_LIMIT = 30;
+const LIMIT_OPTIONS = [6, 9, 12];
 
-const ThemeImage = (props: Props) => {
-  const { srcLight, srcDark, ...rest } = props;
+const dateFormatter = new Intl.DateTimeFormat("ko-KR", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+type SearchParamsRecord = Record<string, string | string[] | undefined>;
+
+type PostsApiSuccess = PaginatedResponse<PostWithRelations>;
+type PostsApiError = Extract<ApiResponse<PostWithRelations[]>, { success: false }>;
+type PostsApiResponse = PostsApiSuccess | PostsApiError;
+
+function getSingleValue(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+function parseNumberParam(
+  rawValue: string | string[] | undefined,
+  defaultValue: number,
+  { min = 1, max = Number.MAX_SAFE_INTEGER }: { min?: number; max?: number } = {},
+): number {
+  const value = getSingleValue(rawValue);
+
+  if (!value) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  if (Number.isNaN(parsed)) {
+    return defaultValue;
+  }
+
+  const normalized = Math.max(min, parsed);
+  return Math.min(normalized, max);
+}
+
+function stripMarkdown(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[[^\]]*\]\(([^)]*)\)/g, "$1")
+    .replace(/[-#>*_~]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildExcerpt(post: PostWithRelations): string {
+  const base = (post.excerpt ?? stripMarkdown(post.content ?? ""))
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!base) {
+    return "설명이 준비 중인 포스트입니다.";
+  }
+
+  if (base.length <= 160) {
+    return base;
+  }
+
+  return `${base.slice(0, 157).trimEnd()}...`;
+}
+
+function formatPostDate(post: PostWithRelations): string {
+  const dateLike = post.publishedAt ?? post.createdAt;
+  const date = typeof dateLike === "string" ? new Date(dateLike) : dateLike;
+
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+
+  return dateFormatter.format(date);
+}
+
+function buildMeta(post: PostWithRelations): string {
+  const parts = [
+    post.category?.name,
+    post.author?.name,
+    formatPostDate(post),
+  ].filter(Boolean) as string[];
+
+  return parts.join(" · ");
+}
+
+async function fetchPosts(page: number, limit: number) {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!baseUrl) {
+    throw new Error("NEXT_PUBLIC_API_URL 환경 변수가 설정되어 있지 않습니다.");
+  }
+
+  const url = new URL("/api/posts", baseUrl);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("limit", String(limit));
+
+  const response = await fetch(url.toString(), {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`포스트 목록을 불러오지 못했습니다. (HTTP ${response.status})`);
+  }
+
+  const json = (await response.json()) as PostsApiResponse;
+
+  if (!json.success) {
+    throw new Error(json.message ?? "포스트 목록을 불러오지 못했습니다.");
+  }
+
+  return {
+    posts: json.data,
+    meta: json.meta,
+  };
+}
+
+function renderLimitOption(option: number, activeLimit: number) {
+  if (option === activeLimit) {
+    return (
+      <span key={option} className={`${styles.limitButton} ${styles.limitButtonActive}`}>
+        {option}
+      </span>
+    );
+  }
 
   return (
-    <>
-      <Image {...rest} src={srcLight} className="imgLight" />
-      <Image {...rest} src={srcDark} className="imgDark" />
-    </>
+    <Link
+      key={option}
+      href={{ pathname: "/", query: { page: 1, limit: option } }}
+      className={styles.limitButton}
+    >
+      {option}
+    </Link>
   );
-};
+}
 
-export default function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams?: Promise<SearchParamsRecord>;
+}) {
+  const resolvedSearchParams = (await searchParams) ?? {};
+  const page = parseNumberParam(resolvedSearchParams.page, DEFAULT_PAGE, { min: 1 });
+  const limit = parseNumberParam(resolvedSearchParams.limit, DEFAULT_LIMIT, {
+    min: 1,
+    max: MAX_LIMIT,
+  });
+
+  let errorMessage: string | null = null;
+  let posts: PostWithRelations[] = [];
+  let meta: PostsApiSuccess["meta"] | null = null;
+
+  try {
+    const result = await fetchPosts(page, limit);
+    posts = result.posts;
+    meta = result.meta;
+  } catch (error) {
+    errorMessage =
+      error instanceof Error
+        ? error.message
+        : "알 수 없는 오류가 발생했습니다.";
+  }
+
+  const sectionTitle = "최신 포스트";
+  const sectionSubtitle =
+    "NEXT_PUBLIC_API_URL 환경의 /api/posts 엔드포인트에서 발행된 글들을 불러옵니다.";
+
+  if (errorMessage || !meta) {
+    const fallbackError = errorMessage ?? "잠시 후 다시 시도해주세요.";
+
+    return (
+      <div className={styles.page}>
+        <header className={styles.header}>
+          <h1 className={styles.title}>{sectionTitle}</h1>
+          <p className={styles.subtitle}>{sectionSubtitle}</p>
+        </header>
+        <div className={styles.error} role="alert">
+          <span className={styles.errorMessage}>포스트를 불러오지 못했습니다.</span>
+          <p>{fallbackError}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = meta.totalPages ?? Math.max(1, Math.ceil(meta.total / meta.limit));
+  const activeLimit = meta.limit ?? limit;
+  const limitOptions = Array.from(new Set([...LIMIT_OPTIONS, activeLimit])).sort(
+    (a, b) => a - b,
+  );
+
   return (
     <div className={styles.page}>
-      <main className={styles.main}>
-        <ThemeImage
-          className={styles.logo}
-          srcLight="turborepo-dark.svg"
-          srcDark="turborepo-light.svg"
-          alt="Turborepo logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol>
-          <li>
-            Get started by editing <code>apps/web/app/page.tsx</code>
-          </li>
-          <li>Save and see your changes instantly.</li>
-        </ol>
+      <header className={styles.header}>
+        <h1 className={styles.title}>{sectionTitle}</h1>
+        <p className={styles.subtitle}>{sectionSubtitle}</p>
+      </header>
 
-        <div className={styles.ctas}>
-          <a
-            className={styles.primary}
-            href="https://vercel.com/new/clone?demo-description=Learn+to+implement+a+monorepo+with+a+two+Next.js+sites+that+has+installed+three+local+packages.&demo-image=%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4K8ZISWAzJ8X1504ca0zmC%2F0b21a1c6246add355e55816278ef54bc%2FBasic.png&demo-title=Monorepo+with+Turborepo&demo-url=https%3A%2F%2Fexamples-basic-web.vercel.sh%2F&from=templates&project-name=Monorepo+with+Turborepo&repository-name=monorepo-turborepo&repository-url=https%3A%2F%2Fgithub.com%2Fvercel%2Fturborepo%2Ftree%2Fmain%2Fexamples%2Fbasic&root-directory=apps%2Fdocs&skippable-integrations=1&teamSlug=vercel&utm_source=create-turbo"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className={styles.logo}
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            href="https://turborepo.com/docs?utm_source"
-            target="_blank"
-            rel="noopener noreferrer"
-            className={styles.secondary}
-          >
-            Read our docs
-          </a>
+      <div className={styles.controls}>
+        <div className={styles.limitSelector}>
+          <span className={styles.limitSelectorLabel}>페이지당</span>
+          {limitOptions.map((option) => renderLimitOption(option, activeLimit))}
+          <span>개</span>
         </div>
-        <Button appName="web" className={styles.secondary}>
-          Open alert
-        </Button>
-      </main>
-      <footer className={styles.footer}>
-        <a
-          href="https://vercel.com/templates?search=turborepo&utm_source=create-next-app&utm_medium=appdir-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          href="https://turborepo.com?utm_source=create-turbo"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to turborepo.com →
-        </a>
-      </footer>
+        <span className={styles.summary}>
+          총 {meta.total.toLocaleString()}개의 포스트 · {meta.page} / {totalPages} 페이지
+        </span>
+      </div>
+
+      {posts.length === 0 ? (
+        <div className={styles.empty} role="status">
+          <span className={styles.errorMessage}>아직 게시된 포스트가 없습니다.</span>
+          <p>새로운 글이 등록되면 가장 먼저 만나보실 수 있어요.</p>
+        </div>
+      ) : (
+        <>
+          <div className={styles.grid}>
+            {posts.map((post) => {
+              const excerpt = buildExcerpt(post);
+              const metaText = buildMeta(post);
+              const tagsText = post.tags
+                ?.slice(0, 3)
+                .map((tag) => `#${tag.name}`)
+                .join("  ") ?? "";
+
+              return (
+                <Card
+                  key={post.id}
+                  className={styles.card}
+                  title={post.title}
+                  href={`/posts/${post.slug}`}
+                  target="_self"
+                  appendUtm={false}
+                >
+                  <>
+                    {metaText ? <span className={styles.meta}>{metaText}</span> : null}
+                    <span className={styles.excerpt}>{excerpt}</span>
+                    {tagsText ? <span>{tagsText}</span> : null}
+                  </>
+                </Card>
+              );
+            })}
+          </div>
+
+          <nav className={styles.pagination} aria-label="페이지네이션">
+            {meta.hasPrev ? (
+              <Link
+                className={styles.paginationButton}
+                href={{ pathname: "/", query: { page: meta.page - 1, limit: meta.limit } }}
+              >
+                이전
+              </Link>
+            ) : (
+              <span
+                className={`${styles.paginationButton} ${styles.paginationButtonDisabled}`}
+                aria-disabled="true"
+              >
+                이전
+              </span>
+            )}
+            <span className={styles.paginationInfo}>
+              {meta.page} / {totalPages} 페이지
+            </span>
+            {meta.hasNext ? (
+              <Link
+                className={styles.paginationButton}
+                href={{ pathname: "/", query: { page: meta.page + 1, limit: meta.limit } }}
+              >
+                다음
+              </Link>
+            ) : (
+              <span
+                className={`${styles.paginationButton} ${styles.paginationButtonDisabled}`}
+                aria-disabled="true"
+              >
+                다음
+              </span>
+            )}
+          </nav>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/card.tsx
+++ b/packages/ui/src/card.tsx
@@ -1,22 +1,39 @@
-import { type JSX } from "react";
+import { type ComponentPropsWithoutRef, type JSX, type ReactNode } from "react";
+
+type CardProps = {
+  className?: string;
+  title: string;
+  children: ReactNode;
+  href: string;
+  appendUtm?: boolean;
+} & Omit<ComponentPropsWithoutRef<"a">, "children" | "href">;
+
+const UTM_QUERY =
+  "utm_source=create-turbo&utm_medium=basic&utm_campaign=create-turbo";
 
 export function Card({
   className,
   title,
   children,
   href,
-}: {
-  className?: string;
-  title: string;
-  children: React.ReactNode;
-  href: string;
-}): JSX.Element {
+  target = "_blank",
+  rel,
+  appendUtm = true,
+  ...anchorProps
+}: CardProps): JSX.Element {
+  const computedHref = appendUtm
+    ? `${href}${href.includes("?") ? "&" : "?"}${UTM_QUERY}`
+    : href;
+
+  const computedRel = rel ?? (target === "_blank" ? "noopener noreferrer" : undefined);
+
   return (
     <a
       className={className}
-      href={`${href}?utm_source=create-turbo&utm_medium=basic&utm_campaign=create-turbo"`}
-      rel="noopener noreferrer"
-      target="_blank"
+      href={computedHref}
+      target={target}
+      rel={computedRel}
+      {...anchorProps}
     >
       <h2>
         {title} <span>-&gt;</span>

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,8 @@
     "DATABASE_URL",
     "NEXTAUTH_SECRET",
     "GOOGLE_CLIENT_ID",
-    "GOOGLE_CLIENT_SECRET"
+    "GOOGLE_CLIENT_SECRET",
+    "ADMIN_EMAIL"
   ],
   "tasks": {
     "build": {
@@ -78,7 +79,8 @@
         ".eslintrc*",
         "eslint.config.*"
       ],
-      "outputLogs": "new-only"
+      "outputLogs": "new-only",
+      "env": ["ADMIN_EMAIL"]
     },
     "format": {
       "inputs": [


### PR DESCRIPTION
## Summary
- fetch posts from `NEXT_PUBLIC_API_URL` with page/limit query parameters and render them as cards in the blog landing page
- refresh the landing page layout with pagination controls, limit selector, and improved empty/error states while leveraging shared UI components
- extend the shared `Card` component and tooling configuration to support the new usage and declare required env vars for linting

## Testing
- pnpm --filter @repo/ui build
- pnpm --filter @repo/ui lint
- pnpm --filter blog-web lint
- pnpm --filter blog-web check-types

------
https://chatgpt.com/codex/tasks/task_e_68c8aca545c08328a2206f24b3198ce8